### PR TITLE
added zenpower to read temps from zen3 CPUs

### DIFF
--- a/psuinfo
+++ b/psuinfo
@@ -247,6 +247,10 @@ def main():
                 # ryzen, multiple Die temperatures for threadripper/Epyc
                 ryzen_die_temps = [sensor.current for sensor in temp["k10temp"] if sensor.label == 'Tdie']
                 output += str(int(max(ryzen_die_temps)))
+            if "zenpower" in temp.keys():
+                # zen3 is not supported in k10.  Fix is to load zenpower and unload k10
+                ryzen_die_temps = [sensor.current for sensor in temp["zenpower"] if sensor.label == 'Tdie']
+                output += str(int(max(ryzen_die_temps)))
             if "coretemp" in temp.keys():
                 # intel
                 output += str(int(temp["coretemp"][0][1]))


### PR DESCRIPTION
Ryzen 3 is not well supported in K10 for reading temps.  The current fix is to unload K10 and load the zenpower module in Linux.  I've added logic to check the zenpower outputs, if they exist.